### PR TITLE
Remove bower dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,12 +36,13 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
+    
+  },
+  "devDependencies": {
     "ember": "~1.13.0",
     "ember-resolver": "~0.1.18",
     "loader.js": "ember-cli/loader.js#3.2.1",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3"
-  },
-  "devDependencies": {
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "handlebars": "~2.0",
     "jasmine": ">= 2.0",
     "sinonjs": "*"


### PR DESCRIPTION
When using this library via `bower`, these dependencies are not actually useful/required.  A consuming application will already need to include some of these, but they are not directly required by ember-oauth2 as far as I can tell.

Please feel free to close this if I have misunderstood things here...