### PR TITLE
Fix typo in ember-oauth2.js

### DIFF
--- a/addon/services/ember-oauth2.js
+++ b/addon/services/ember-oauth2.js
@@ -237,7 +237,7 @@ export default Ember.Service.extend(Ember.Evented, {
         '&client_id=' + encodeURIComponent(this.get('clientId')) +
         '&state=' + encodeURIComponent(this.get('state'));
     if (this.get('scope')) { 
-      uri += '&scope=' + encodeURIComponent(this.get('.scope')).replace('%20', '+');
+      uri += '&scope=' + encodeURIComponent(this.get('scope')).replace('%20', '+');
     }
     return uri;
   },


### PR DESCRIPTION
If a "scope" is defined, Ember would fail with `Assertion Failed: Cannot call `Ember.get` with an empty string`, due to the `get('.scope')` call. This should fix it.