### PR TITLE
Add ember-cli-babel as a dependency (not devDep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
   "engines": {
     "node": ">= 0.10.0"
   },
+  "dependencies": {
+    "ember-cli-babel": "^5.1.6"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",


### PR DESCRIPTION
I was seeing the following warning message when building the app:
> DEPRECATION: Addon files were detected in `app-directory/node_modules/ember-oauth2/addon`, but no JavaScript preprocessors were found for `ember-oauth2`. Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-oauth2`'s `package.json`.

Did the same fix as in https://github.com/ember-cli/ember-load-initializers/issues/40.
The addon is working fine for me after this change.